### PR TITLE
Adding setup.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "setuptools_scm", "pybind11"]
+build-backend = 'setuptools.build_meta'

--- a/python/fastchem_python_wrapper.cpp
+++ b/python/fastchem_python_wrapper.cpp
@@ -1,5 +1,5 @@
-#include "../_deps/pybind11-src/include/pybind11/pybind11.h"
-#include "../_deps/pybind11-src/include/pybind11/stl.h"
+#include "pybind11/pybind11.h"
+#include "pybind11/stl.h"
 #include "../fastchem_src/fastchem.h"
 #include "../fastchem_src/input_output_struct.h"
 #include "../fastchem_src/fastchem_constants.h"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,24 @@
+from glob import glob
+from setuptools import setup
+from pybind11.setup_helpers import Pybind11Extension, build_ext
+
+
+__version__ = "2.0"
+
+ext_modules = [
+    Pybind11Extension(
+        "pyfastchem",
+        sorted(glob("model_src/*.cpp") +
+               glob("fastchem_src/*.cpp") +
+               glob("python/*.cpp")),
+    ),
+]
+
+setup(
+    name="pyfastchem",
+    author="Daniel Kitzmann, Joachim Stock, Brett Morris",
+    url="https://github.com/exoclime/FastChem",
+    version=__version__,
+    ext_modules=ext_modules,
+    cmdclass={"build_ext": build_ext}
+)


### PR DESCRIPTION
Hi @daniel-kitzmann, 

One more feature for pyfastchem users here. It's traditional to install python packages using Python itself, rather than building with cmake first and generating a standalone shared library. The advantages to doing this include: 
* the typical call to `python setup.py install` will work
* the package `pyfastchem` will be installed at the system level, so that it can be imported anywhere, without specifying the path to the shared library
* the average Python user needs to know less C to make the install happen

With this addition, you can simply `cd` into the repo and type `python setup.py install` to install the package.

Also, if you approve of these changes and want me to handle it for you, I can also upload pyfastchem to PyPI (this is something I need for one of my projects), so it can also be installed simply with `pip install pyfastchem`. 